### PR TITLE
sepolicy: Label our modem partitions

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -17,6 +17,11 @@
 
 /dev/rfkill                            u:object_r:rfkill_device:s0
 
+# Block devices
+/dev/block/platform/msm_sdcc\.1/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/modemst2          u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/fsg               u:object_r:modem_efs_partition_device:s0
+
 /data/system/default_values            u:object_r:mpctl_data_file:s0
 
 /data/etc/wlan.*                       u:object_r:wifi_data_file:s0


### PR DESCRIPTION
https://github.com/CyanogenMod/android_system_core/commit/d89b1977189ce55f297d059b2e3dc2433f303067
fixes the bug which let us have '/dev/block/bootdevice' even when
we didn't have 'androidboot.bootdevice' set on the cmdline.

Change-Id: I01fc39e0b565255d599653fc1454282af3c927cb